### PR TITLE
docs: removed @types/xspreadsheet from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 npm install typescript --save-dev
 npm install awesome-typescript-loader --save-dev
 npm install xspreadsheet --save-dev
-npm install @types/xspreadsheet --save-dev
 ```
 
 ## Quick Start


### PR DESCRIPTION
I found there are no `@types/xspreadsheet` typings in `DefinitelyTyped` as well as in `npm`.